### PR TITLE
feat: add shortlink analytics and admin tools

### DIFF
--- a/admin.html
+++ b/admin.html
@@ -183,9 +183,13 @@
             </form>
             <form id="shortlink-form" class="p-6 space-y-5 overflow-y-auto hidden">
                 <input type="hidden" id="shortlink-id">
-                 <div>
+                <input type="hidden" id="shortlink-clicks">
+                <div>
                     <label for="shortlink-slug" class="block text-sm font-medium text-secondary mb-2">Short Link (e.g., 'cv' for ardhan.my.id/cv)</label>
-                    <input type="text" id="shortlink-slug" class="input-style" placeholder="cv" required>
+                    <div class="flex items-center space-x-2">
+                        <input type="text" id="shortlink-slug" class="input-style flex-grow" placeholder="cv" required>
+                        <button type="button" id="generate-slug" class="px-3 py-2 rounded-md btn-secondary-bg btn-secondary-text">Random</button>
+                    </div>
                 </div>
                 <div>
                     <label for="shortlink-url" class="block text-sm font-medium text-secondary mb-2">Original URL (The link to redirect to)</label>
@@ -199,10 +203,20 @@
         </div>
     </div>
 
+    <div id="details-modal" class="fixed inset-0 bg-black bg-opacity-70 z-50 hidden items-center justify-center p-4">
+        <div class="bg-secondary rounded-2xl shadow-xl w-full max-w-3xl max-h-full overflow-hidden flex flex-col modal-content transform scale-95 opacity-0">
+            <div class="flex justify-between items-center p-5 border-b border-color">
+                <h2 id="details-title" class="text-2xl font-bold text-primary"></h2>
+                <button id="close-details-btn" class="p-2 rounded-full hover:bg-primary text-secondary hover:text-primary transition-colors"><i class="fas fa-times"></i></button>
+            </div>
+            <div id="details-content" class="p-6 overflow-y-auto"></div>
+        </div>
+    </div>
+
     <script type="module">
         import { initializeApp } from "https://www.gstatic.com/firebasejs/11.9.0/firebase-app.js";
         import { getAuth, onAuthStateChanged, signInWithEmailAndPassword, signOut } from "https://www.gstatic.com/firebasejs/11.9.0/firebase-auth.js";
-        import { getFirestore, collection, doc, onSnapshot, addDoc, updateDoc, deleteDoc, serverTimestamp, getDoc, setDoc } from "https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js";
+        import { getFirestore, collection, doc, onSnapshot, addDoc, updateDoc, deleteDoc, serverTimestamp, getDoc, setDoc, query, orderBy, getDocs } from "https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js";
 
         // --- Firebase Initialization ---
         const firebaseConfig = {
@@ -314,11 +328,11 @@
 
         function renderShortlinks(items) {
             const container = document.getElementById('content-area');
-             if (items.length === 0) {
+            if (items.length === 0) {
                 container.innerHTML = `<div class="text-center py-20 bg-secondary rounded-lg border-2 border-dashed border-color">
                     <i class="fas fa-folder-open fa-3x text-secondary"></i>
                     <p class="mt-4 text-lg font-medium text-primary">No shortlinks yet.</p>
-                    <p class="text-secondary">Click "Add New Item" to create one.</p>
+                    <p class="text-secondary">Click \"Add New Item\" to create one.</p>
                 </div>`;
                 return;
             }
@@ -329,6 +343,7 @@
                             <tr>
                                 <th class="p-4 font-semibold text-primary">Short Link</th>
                                 <th class="p-4 font-semibold text-primary">Original URL</th>
+                                <th class="p-4 font-semibold text-primary">Clicks</th>
                                 <th class="p-4 font-semibold text-primary text-right">Actions</th>
                             </tr>
                         </thead>
@@ -337,7 +352,10 @@
                                 <tr class="border-b border-color last:border-b-0">
                                     <td class="p-4 text-blue-500 align-middle font-mono">ardhan.my.id/${item.id}</td>
                                     <td class="p-4 text-secondary align-middle truncate max-w-sm">${item.url}</td>
+                                    <td class="p-4 text-secondary align-middle">${item.clicks || 0}</td>
                                     <td class="p-4 text-right align-middle">
+                                        <button class="view-btn text-green-500 hover:text-green-700 p-2 mr-2" data-id="${item.id}"><i class="fas fa-eye"></i></button>
+                                        <button class="edit-btn text-blue-500 hover:text-blue-700 p-2 mr-2" data-id="${item.id}"><i class="fas fa-pencil-alt"></i></button>
                                         <button class="delete-btn text-red-500 hover:text-red-700 p-2" data-id="${item.id}"><i class="fas fa-trash"></i></button>
                                     </td>
                                 </tr>
@@ -346,6 +364,8 @@
                     </table>
                 </div>`;
             container.querySelectorAll('.delete-btn').forEach(btn => btn.addEventListener('click', handleDelete));
+            container.querySelectorAll('.edit-btn').forEach(btn => btn.addEventListener('click', handleEdit));
+            container.querySelectorAll('.view-btn').forEach(btn => btn.addEventListener('click', handleView));
         }
 
 
@@ -360,13 +380,22 @@
         const modalContent = modal.querySelector('.modal-content');
         const itemForm = document.getElementById('item-form');
         const shortlinkForm = document.getElementById('shortlink-form');
+        const detailsModal = document.getElementById('details-modal');
+        const detailsContent = document.getElementById('details-content');
+        const detailsModalContent = detailsModal.querySelector('.modal-content');
+
+        document.getElementById('generate-slug').addEventListener('click', () => {
+            const rand = Math.random().toString(36).substring(2,8);
+            document.getElementById('shortlink-slug').value = rand;
+        });
+        document.getElementById('close-details-btn').addEventListener('click', closeDetails);
         
-        function openModal() { 
-            modal.classList.remove('hidden'); 
-            modal.classList.add('flex'); 
-            setTimeout(() => modalContent.classList.remove('scale-95', 'opacity-0'), 50); 
+        function openModal() {
+            modal.classList.remove('hidden');
+            modal.classList.add('flex');
+            setTimeout(() => modalContent.classList.remove('scale-95', 'opacity-0'), 50);
         }
-        function closeModal() { 
+        function closeModal() {
             modalContent.classList.add('scale-95', 'opacity-0');
             setTimeout(() => { 
                 modal.classList.add('hidden'); 
@@ -374,7 +403,20 @@
                 shortlinkForm.reset();
                 itemForm.classList.add('hidden');
                 shortlinkForm.classList.add('hidden');
-            }, 300); 
+            }, 300);
+        }
+
+        function openDetails() {
+            detailsModal.classList.remove('hidden');
+            detailsModal.classList.add('flex');
+            setTimeout(() => detailsModalContent.classList.remove('scale-95', 'opacity-0'), 50);
+        }
+        function closeDetails() {
+            detailsModalContent.classList.add('scale-95', 'opacity-0');
+            setTimeout(() => {
+                detailsModal.classList.add('hidden');
+                detailsContent.innerHTML = '';
+            }, 300);
         }
         
         function setupModalListeners() {
@@ -384,7 +426,8 @@
                 
                 if (currentCollection === 'shortlinks') {
                     shortlinkForm.reset();
-                    document.getElementById('shortlink-id').value = ''; // No ID for new shortlinks
+                    document.getElementById('shortlink-id').value = '';
+                    document.getElementById('shortlink-clicks').value = 0;
                     document.getElementById('modal-title').textContent = `Add New Shortlink`;
                     shortlinkForm.classList.remove('hidden');
                     itemForm.classList.add('hidden');
@@ -410,17 +453,25 @@
             const docSnap = await getDoc(docRef);
             if (docSnap.exists()) {
                 const item = docSnap.data();
-                itemForm.classList.remove('hidden');
-                shortlinkForm.classList.add('hidden');
-
-                document.getElementById('item-id').value = id;
-                document.getElementById('item-type-collection').value = currentCollection;
-                document.getElementById('item-title').value = item.title;
-                document.getElementById('item-image').value = item.imageUrl;
-                document.getElementById('item-external-url').value = item.externalUrl || '';
-                quill.root.innerHTML = item.content || '';
-                
-                document.getElementById('modal-title').textContent = `Editing: ${item.title}`;
+                if (currentCollection === 'shortlinks') {
+                    shortlinkForm.classList.remove('hidden');
+                    itemForm.classList.add('hidden');
+                    document.getElementById('shortlink-id').value = id;
+                    document.getElementById('shortlink-clicks').value = item.clicks || 0;
+                    document.getElementById('shortlink-slug').value = id;
+                    document.getElementById('shortlink-url').value = item.url;
+                    document.getElementById('modal-title').textContent = `Editing: ${id}`;
+                } else {
+                    itemForm.classList.remove('hidden');
+                    shortlinkForm.classList.add('hidden');
+                    document.getElementById('item-id').value = id;
+                    document.getElementById('item-type-collection').value = currentCollection;
+                    document.getElementById('item-title').value = item.title;
+                    document.getElementById('item-image').value = item.imageUrl;
+                    document.getElementById('item-external-url').value = item.externalUrl || '';
+                    quill.root.innerHTML = item.content || '';
+                    document.getElementById('modal-title').textContent = `Editing: ${item.title}`;
+                }
                 openModal();
             }
         }
@@ -432,16 +483,39 @@
             }
         }
 
+        async function handleView(e) {
+            const { id } = e.currentTarget.dataset;
+            const visitsRef = collection(db, `shortlinks/${id}/visits`);
+            const q = query(visitsRef, orderBy('timestamp', 'desc'));
+            const snap = await getDocs(q);
+            let rows = '';
+            snap.forEach(docSnap => {
+                const data = docSnap.data();
+                const loc = [data.country, data.region, data.city].filter(Boolean).join(', ');
+                rows += `<tr class="border-b border-color last:border-b-0"><td class="p-2">${data.ip || ''}</td><td class="p-2">${loc}</td><td class="p-2">${data.timestamp ? new Date(data.timestamp.toDate()).toLocaleString() : ''}</td></tr>`;
+            });
+            if (!rows) rows = '<tr><td class="p-2" colspan="3">No visits yet.</td></tr>';
+            detailsContent.innerHTML = `<table class="w-full text-left"><thead class="border-b border-color"><tr><th class="p-2">IP</th><th class="p-2">Location</th><th class="p-2">Time</th></tr></thead><tbody>${rows}</tbody></table>`;
+            document.getElementById('details-title').textContent = `Visits for ${id}`;
+            openDetails();
+        }
+
         async function handleSave() {
             if (currentCollection === 'shortlinks') {
                 const slug = document.getElementById('shortlink-slug').value.trim();
                 const url = document.getElementById('shortlink-url').value.trim();
+                const oldId = document.getElementById('shortlink-id').value;
+                const clicks = parseInt(document.getElementById('shortlink-clicks').value || '0');
                 if (!slug || !url) {
                     alert('Please provide both a short link and an original URL.');
                     return;
                 }
-                // For shortlinks, the ID is the slug itself. We use setDoc.
-                await setDoc(doc(db, "shortlinks", slug), { url: url });
+                if (oldId && oldId !== slug) {
+                    await deleteDoc(doc(db, 'shortlinks', oldId));
+                    await setDoc(doc(db, 'shortlinks', slug), { url, clicks });
+                } else {
+                    await setDoc(doc(db, 'shortlinks', slug), { url }, { merge: true });
+                }
             } else {
                  const id = document.getElementById('item-id').value;
                 const collectionName = document.getElementById('item-type-collection').value;

--- a/redirect.html
+++ b/redirect.html
@@ -18,7 +18,7 @@
 
     <script type="module">
         import { initializeApp } from "https://www.gstatic.com/firebasejs/11.9.0/firebase-app.js";
-        import { getFirestore, doc, getDoc } from "https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js";
+        import { getFirestore, doc, getDoc, updateDoc, collection, addDoc, serverTimestamp, increment } from "https://www.gstatic.com/firebasejs/11.9.0/firebase-firestore.js";
 
         const firebaseConfig = {
             apiKey: "AIzaSyCCzxxZ0pujMyzvvRorepkzaBWwO1RhUsg",
@@ -31,15 +31,29 @@
         const app = initializeApp(firebaseConfig);
         const db = getFirestore(app);
 
+        async function logVisit(docRef) {
+            let visit = { userAgent: navigator.userAgent };
+            try {
+                const res = await fetch('https://ipapi.co/json/');
+                const data = await res.json();
+                visit.ip = data.ip;
+                visit.country = data.country_name;
+                visit.region = data.region;
+                visit.city = data.city;
+            } catch (err) {
+                console.error('Failed to fetch visitor info', err);
+            }
+            visit.timestamp = serverTimestamp();
+            await addDoc(collection(docRef, 'visits'), visit);
+            await updateDoc(docRef, { clicks: increment(1) });
+        }
+
         async function handleRedirect() {
-            // Get the path from the URL, e.g., "/my-link"
             const path = window.location.pathname;
-            
-            // Remove the leading slash to get the slug
             const slug = path.substring(1);
 
             if (!slug) {
-                window.location.href = '/index.html'; // Redirect to home if no slug
+                window.location.href = '/index.html';
                 return;
             }
 
@@ -48,15 +62,13 @@
                 const docSnap = await getDoc(docRef);
 
                 if (docSnap.exists()) {
-                    // Redirect to the original URL
+                    await logVisit(docRef);
                     window.location.href = docSnap.data().url;
                 } else {
-                    // If link doesn't exist, go to the homepage
                     window.location.href = '/index.html';
                 }
             } catch (error) {
                 console.error("Error fetching shortlink:", error);
-                // On error, also redirect to homepage
                 window.location.href = '/index.html';
             }
         }


### PR DESCRIPTION
## Summary
- track visitor IP/location and increment click counts before redirecting shortlinks
- manage shortlinks in admin panel with click statistics, visit details, and random slug generation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c079462fac832eaf53ecf8b1d53bff